### PR TITLE
修复windows上的编译错误：snprintf问题

### DIFF
--- a/CJsonObject.cpp
+++ b/CJsonObject.cpp
@@ -10,6 +10,10 @@
 
 #include "CJsonObject.hpp"
 
+#ifdef _WIN32
+#define snprintf _snprintf_s
+#endif
+
 namespace neb
 {
 


### PR DESCRIPTION
简单改了下，细改的话把snprintf和_snprintf_s define成CJsnprintf