### PR TITLE
加入CJsonObject::Override函数

### DIFF
--- a/CJsonObject.hpp
+++ b/CJsonObject.hpp
@@ -92,7 +92,12 @@ public:     // method of ordinary json object
     bool Replace(const std::string& strKey, float fValue);
     bool Replace(const std::string& strKey, double dValue);
     bool ReplaceWithNull(const std::string& strKey);    // replace value with null
-
+    template <typename T> bool Override(const std::string& strKey,T& value) 
+    {
+      if(Replace(strKey,value) == false)
+        return Add(strKey,value);
+      return true;
+    }
 public:     // method of json array
     int GetArraySize();
     CJsonObject& operator[](unsigned int uiWhich);


### PR DESCRIPTION
功能：当使用CJsonObject::Replace失败时调用CJsonObject::Add创建他，在不知道目标是否存在时免去用户自行判断的操作，实现即使不知道对应键值的项是否存在，仍能有效的实现覆盖