### PR TITLE
bug repair：ReplaceAdd()

### DIFF
--- a/CJsonObject.cpp
+++ b/CJsonObject.cpp
@@ -1305,6 +1305,20 @@ bool CJsonObject::Add(const std::string& strKey, double dValue)
     return(true);
 }
 
+bool CJsonObject::ReplaceAdd(const std::string& strKey,const CJsonObject& oJsonObject)
+{
+  if(Replace(strKey,oJsonObject) == false)
+    return Add(strKey,oJsonObject);
+  return true;
+}
+
+bool CJsonObject::ReplaceAdd(const std::string& strKey,const std::string& strValue)
+{
+  if(Replace(strKey,strValue) == false)
+    return Add(strKey,strValue);
+  return true;
+}
+
 bool CJsonObject::AddNull(const std::string& strKey)
 {
     cJSON* pFocusData = NULL;

--- a/CJsonObject.hpp
+++ b/CJsonObject.hpp
@@ -92,7 +92,9 @@ public:     // method of ordinary json object
     bool Replace(const std::string& strKey, float fValue);
     bool Replace(const std::string& strKey, double dValue);
     bool ReplaceWithNull(const std::string& strKey);    // replace value with null
-    template <typename T> bool ReplaceAdd(const std::string& strKey,T& value) 
+    bool ReplaceAdd(const std::string& strKey,const CJsonObject& oJsonObject);
+    bool ReplaceAdd(const std::string& strKey,const std::string& strValue);
+    template <typename T> bool ReplaceAdd(const std::string& strKey,T value) 
     {
       if(Replace(strKey,value) == false)
         return Add(strKey,value);


### PR DESCRIPTION
修复之前加入的 CJsonObject::ReplaceAdd函数的bug，由于Add函数的对象值有引用与直接传参两种方式，所以需要分开定义而不能只使用同一个函数模板