### PR TITLE
format error in function print_int

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -209,7 +209,11 @@ static char *print_int(cJSON *item)
             }
             else
             {
+#if LLONG_MAX==LONG_MAX
                 sprintf(str, "%ld", (int64)item->valueint);
+#else
+                sprintf(str, "%lld", (int64)item->valueint);
+#endif
             }
         }
         else
@@ -220,7 +224,11 @@ static char *print_int(cJSON *item)
             }
             else
             {
-                sprintf(str, "%lu", item->valueint);
+#if LLONG_MAX==LONG_MAX
+                sprintf(str, "%lu", (uint64)item->valueint);
+#else
+                sprintf(str, "%llu", (uint64)item->valueint);
+#endif
             }
         }
     }


### PR DESCRIPTION
My code is like this:

size_t sz = 128849018888;
neb::CJsonObject json;
json.Add("a", sz);
printf("%s\n", json.ToString().c_str());

Output is: {"a":0}

Obviously, the output is not right. After checking the code, I found the problem.

Meanwhile, I found other problems: #if LLONG_MAX==LLONG_MAX, but I has been fixed in new version.