### PR TITLE
[CHG] Fix memory leak

### DIFF
--- a/CJsonObject.cpp
+++ b/CJsonObject.cpp
@@ -85,6 +85,8 @@ CJsonObject& CJsonObject::operator=(const CJsonObject& oJsonObject)
 #if __cplusplus >= 201101L
 CJsonObject& CJsonObject::operator=(CJsonObject&& oJsonObject)
 {
+    Clear();
+    
     m_pJsonData = oJsonObject.m_pJsonData;
     oJsonObject.m_pJsonData = NULL;
     m_pExternJsonDataRef = oJsonObject.m_pExternJsonDataRef;


### PR DESCRIPTION
### BUGS FOUND

Need clear self before using `operator =(CJsonObject&& ) ` with rvalue to cover member in CJsonObject

``` cpp
CJsonObject FuncA()
{
    /*....*/
   return CJsonObject();
}

void main()
{
    CJsonObject  Ocjson;
    /*....*/
    // Memory leak found
    Ocjson =  FuncA();
    /*....*/
}
```
 